### PR TITLE
Fix attribute parser

### DIFF
--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -207,4 +207,14 @@ describe('parseAttributes', () => {
 
         expect(parseAttributes(input)).toEqual(expected);
     });
+
+    test('should handle attributes with multiple hyphens', () => {
+        const input = 'data-long-attribute-name="value" another-attr="test"';
+        const expected = {
+            'data-long-attribute-name': 'value',
+            'another-attr': 'test',
+        };
+
+        expect(parseAttributes(input)).toEqual(expected);
+    });
 });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -358,7 +358,7 @@ export function deepSet(
  * @returns An object where each key is the name of an attribute and each value is the corresponding attribute value parsed from the input string.
  */
 export function parseAttributes(input: string): Record<string, string> {
-    const attributeValueRegex = /(\w+-?\w*)=["']([^"']*)["']/g;
+    const attributeValueRegex = /([\w-]+)=["']([^"']*)["']/g;
     const attributes: Record<string, string> = {};
 
     let match: RegExpExecArray | null;


### PR DESCRIPTION
## Summary
- fix regex in parseAttributes to handle multi-hyphen attributes
- add test coverage for multi-hyphen attributes

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_683fb7dcc044832680a6ed192e3772a9