### PR TITLE
Improve parseAttributes regex test

### DIFF
--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -207,4 +207,14 @@ describe('parseAttributes', () => {
 
         expect(parseAttributes(input)).toEqual(expected);
     });
+
+    test('should handle attributes with multiple hyphens', () => {
+        const input = 'data-custom-id="abc" data-long-name="xyz"';
+        const expected = {
+            'data-custom-id': 'abc',
+            'data-long-name': 'xyz',
+        };
+
+        expect(parseAttributes(input)).toEqual(expected);
+    });
 });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -358,7 +358,7 @@ export function deepSet(
  * @returns An object where each key is the name of an attribute and each value is the corresponding attribute value parsed from the input string.
  */
 export function parseAttributes(input: string): Record<string, string> {
-    const attributeValueRegex = /(\w+-?\w*)=["']([^"']*)["']/g;
+    const attributeValueRegex = /([\w-]+)=["']([^"']*)["']/g;
     const attributes: Record<string, string> = {};
 
     let match: RegExpExecArray | null;


### PR DESCRIPTION
## Summary
- support attribute names with multiple hyphens in `parseAttributes`
- test parsing of attributes with multiple hyphens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fc1d4e404832697518aa9a0706750