### PR TITLE
Add Playwright visual regression testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ dist
 # End of https://www.toptal.com/developers/gitignore/api/node
 
 /build
+# Playwright
+playwright-report/
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
       },
       "devDependencies": {
         "@next/bundle-analyzer": "^14.0.4",
+        "@playwright/test": "^1.52.0",
         "@types/jest": "^29.5.6",
         "@types/node": "20.8.7",
         "@types/react": "^18.2.31",
@@ -2529,6 +2530,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -16194,6 +16211,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "next lint --max-warnings 0",
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
-    "generate-fixtures": "./scripts/generate-fixtures.sh"
+    "generate-fixtures": "./scripts/generate-fixtures.sh",
+    "test:visual": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -77,6 +78,7 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^14.0.4",
+    "@playwright/test": "^1.52.0",
     "@types/jest": "^29.5.6",
     "@types/node": "20.8.7",
     "@types/react": "^18.2.31",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './visual-tests',
+  use: {
+    baseURL: 'http://localhost:3000',
+    screenshot: 'only-on-failure',
+    viewport: { width: 1280, height: 720 },
+  },
+  expect: {
+    toHaveScreenshot: {
+      threshold: 0.2,
+    },
+  },
+});

--- a/visual-tests/homepage.spec.ts
+++ b/visual-tests/homepage.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('homepage visual regression', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveScreenshot('homepage.png');
+});


### PR DESCRIPTION
## Summary
- install `@playwright/test`
- add visual test runner script
- ignore Playwright output folders
- set up Playwright config with screenshot comparisons
- create example homepage visual test

## Testing
- `npm test`
- `npx playwright test` *(fails: Executable doesn't exist; run `npx playwright install` to download browsers)*

------
https://chatgpt.com/codex/tasks/task_e_683fd3209c4083268ef61977369a7fff